### PR TITLE
Advance to 3.1, add warning to Telemetry

### DIFF
--- a/cryptocurrency-sentiment-analysis/pom.xml
+++ b/cryptocurrency-sentiment-analysis/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.jet.demos</groupId>
         <artifactId>hazelcast-jet-demos</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
     </parent>
 
     <name>Twitter Cryptocurrency Sentiment Analysis</name>

--- a/flight-telemetry/README.md
+++ b/flight-telemetry/README.md
@@ -77,3 +77,9 @@ Note: The ADB-S data stream publishes ~3 MB of data per update. We are polling i
 
 This demo uses data provided by [ADB-S Exchange](https://www.adsbexchange.com/). Please consider supporting ADB-S Exchange by a [donation](https://www.adsbexchange.com/donate/) or by hosting a [feeder](https://www.adsbexchange.com/how-to-feed/).
 
+# IMPORTANT
+
+For this demo to work, you need an API key in `src/main/java/com/hazelcast/jet/demo/FlightDataSource.java`.
+
+Follow the instructions [here](https://www.adsbexchange.com/data/) to obtain one.
+

--- a/flight-telemetry/pom.xml
+++ b/flight-telemetry/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.jet.demos</groupId>
         <artifactId>hazelcast-jet-demos</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
     </parent>
 
     <name>ADB-S Flight Telemetry Stream Processing Demo</name>

--- a/flight-telemetry/src/main/java/com/hazelcast/jet/demo/FlightDataSource.java
+++ b/flight-telemetry/src/main/java/com/hazelcast/jet/demo/FlightDataSource.java
@@ -35,7 +35,7 @@ public class FlightDataSource {
      * See <a href="https://www.adsbexchange.com/data/">ADS-B Exchange</a> for how to
      * obtain an API key.
      */
-    private static final String API_AUTHENTICATION_KEY = "YOUR_API_KEY_HERE";
+    protected static final String API_AUTHENTICATION_KEY = "YOUR_API_KEY_HERE";
 
     private final URL url;
     private final long pollIntervalMillis;

--- a/flight-telemetry/src/main/java/com/hazelcast/jet/demo/FlightTelemetry.java
+++ b/flight-telemetry/src/main/java/com/hazelcast/jet/demo/FlightTelemetry.java
@@ -148,6 +148,11 @@ public class FlightTelemetry {
     }
 
     public static void main(String[] args) {
+        if (FlightDataSource.API_AUTHENTICATION_KEY.equals("YOUR_API_KEY_HERE")) {
+             System.err.println("API_AUTHENTICATION_KEY not set in FlightDataSource.java");
+             System.exit(1);
+        }
+
         JetInstance jet = getJetInstance();
 
         Pipeline pipeline = buildPipeline();

--- a/jetleopard/pom.xml
+++ b/jetleopard/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.hazelcast.jet.demos</groupId>
         <artifactId>hazelcast-jet-demos</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
     </parent>
 
     <properties>

--- a/market-data-ingest/common/pom.xml
+++ b/market-data-ingest/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.hazelcast.jet.demos.market-data-ingest</groupId>
 		<artifactId>market-data-ingest</artifactId>
-		<version>3.0</version>
+		<version>3.1</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/market-data-ingest/hazelcast-grid/pom.xml
+++ b/market-data-ingest/hazelcast-grid/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.hazelcast.jet.demos.market-data-ingest</groupId>
 		<artifactId>market-data-ingest</artifactId>
-		<version>3.0</version>
+		<version>3.1</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/market-data-ingest/hazelcast-grid/src/main/resources/hazelcast.xml
+++ b/market-data-ingest/hazelcast-grid/src/main/resources/hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast
-	xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+	xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.12.xsd"
 	xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
 	<group>

--- a/market-data-ingest/kafka-writer/pom.xml
+++ b/market-data-ingest/kafka-writer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.hazelcast.jet.demos.market-data-ingest</groupId>
 		<artifactId>market-data-ingest</artifactId>
-		<version>3.0</version>
+		<version>3.1</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/market-data-ingest/pom.xml
+++ b/market-data-ingest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.hazelcast.jet.demos</groupId>
 		<artifactId>hazelcast-jet-demos</artifactId>
-		<version>3.0</version>
+		<version>3.1</version>
 	</parent>
 
 	<name>Market Data Ingestion</name>

--- a/markov-chain-generator/pom.xml
+++ b/markov-chain-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.jet.demos</groupId>
         <artifactId>hazelcast-jet-demos</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
     </parent>
 
     <name>Markov Chain Generator</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hazelcast.jet.demos</groupId>
     <artifactId>hazelcast-jet-demos</artifactId>
-    <version>3.0</version>
+    <version>3.1</version>
     <packaging>pom</packaging>
     <name>Hazelcast Jet Demo Applications</name>
 
@@ -44,7 +44,7 @@
 
     <properties>
         <jdk.version>1.8</jdk.version>
-        <hazelcast-jet.version>3.0</hazelcast-jet.version>
+        <hazelcast-jet.version>3.1</hazelcast-jet.version>
         <maven.compiler.plugin.version>2.5.1</maven.compiler.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/realtime-image-recognition/pom.xml
+++ b/realtime-image-recognition/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.jet.demos</groupId>
         <artifactId>hazelcast-jet-demos</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
     </parent>
 
     <name>Real-time Image Recognition Demo</name>

--- a/road-traffic-predictor/pom.xml
+++ b/road-traffic-predictor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.jet.demos</groupId>
         <artifactId>hazelcast-jet-demos</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
     </parent>
 
     <artifactId>road-traffic-predictor</artifactId>


### PR DESCRIPTION
Update the demos to use Jet 3.1, just `pom.xml` changes.

Clarify the `flight-telemetry` demo to mention the need for API key